### PR TITLE
Reduce initial FOUC by preloading styles

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -12,7 +12,14 @@ export const links: LinksFunction = () => [
   { rel: "preconnect", href: "https://cdn.shopify.com", crossOrigin: "anonymous" },
   { rel: "dns-prefetch", href: "https://img.youtube.com" },
   { rel: "preconnect", href: "https://img.youtube.com", crossOrigin: "anonymous" },
+  {
+    rel: "preload",
+    href: "https://cdn.shopify.com/static/fonts/inter/v4/styles.css",
+    as: "style",
+    crossOrigin: "anonymous",
+  },
   { rel: "stylesheet", href: "https://cdn.shopify.com/static/fonts/inter/v4/styles.css" },
+  { rel: "preload", href: polarisStylesUrl, as: "style" },
   { rel: "stylesheet", href: polarisStylesUrl },
 ];
 
@@ -106,6 +113,12 @@ function AppWithTranslations({
             suppressHydrationWarning
             dangerouslySetInnerHTML={{
               __html: createAppBridgeConfigScript({ apiKey, host, shop }),
+            }}
+          />
+          <style
+            suppressHydrationWarning
+            dangerouslySetInnerHTML={{
+              __html: `:root{color-scheme:light;}body{margin:0;background-color:#f4f6f8;color:#202223;min-height:100vh;-webkit-font-smoothing:antialiased;}`,
             }}
           />
           <Meta />


### PR DESCRIPTION
## Summary
- add preload hints for Inter and Polaris stylesheets
- inline minimal fallback styles to keep layout stable before Polaris CSS hydrates

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fa1f746d9083338c902a3a5f6dcd76